### PR TITLE
Add responsive projects carousel with images

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,29 +61,29 @@
             <div class="carousel-track-container">
                 <div class="carousel-track">
                     <div class="carousel-slide">
+                        <img src="assets/wheels-up.png" alt="Wheels Up screenshot" class="project-image" />
                         <h3>Wheels Up</h3>
-                        <div class="project-image">Image Placeholder</div>
                         <p>Aircraft loading planner</p>
                     </div>
                     <div class="carousel-slide">
+                        <img src="assets/inventory-tracker.png" alt="Inventory Tracker screenshot" class="project-image" />
                         <h3>Inventory Tracker</h3>
-                        <div class="project-image">Image Placeholder</div>
-                        <p>Office supply management</p>
+                        <p>Track and manage office supplies</p>
                     </div>
                     <div class="carousel-slide">
+                        <img src="assets/budget-balanced.png" alt="Budget Balanced screenshot" class="project-image" />
                         <h3>Budget Balanced</h3>
-                        <div class="project-image">Image Placeholder</div>
-                        <p>Personal budgeting made simple</p>
+                        <p>Personal budgeting app</p>
                     </div>
                     <div class="carousel-slide">
-                        <h3>Wedding Coordinator App</h3>
-                        <div class="project-image">Image Placeholder</div>
-                        <p>Plan and manage your wedding</p>
+                        <img src="assets/marriage-managed.png" alt="Marriage Managed screenshot" class="project-image" />
+                        <h3>Marriage Managed</h3>
+                        <p>Wedding planning assistant</p>
                     </div>
                     <div class="carousel-slide">
-                        <h3>Business Directory</h3>
-                        <div class="project-image">Image Placeholder</div>
-                        <p>A smarter way to find local businesses</p>
+                        <img src="assets/business-directory.png" alt="US Business Directory screenshot" class="project-image" />
+                        <h3>US Business Directory</h3>
+                        <p>Private directory for sourcing</p>
                     </div>
                 </div>
             </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,12 @@
+import ProjectsCarousel from './components/ProjectsCarousel.jsx';
+
+export default function App() {
+  return (
+    <div>
+      <section id="projects">
+        <h2>Our Projects</h2>
+        <ProjectsCarousel />
+      </section>
+    </div>
+  );
+}

--- a/src/components/ProjectsCarousel.jsx
+++ b/src/components/ProjectsCarousel.jsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+
+const projects = [
+  {
+    title: 'Wheels Up',
+    image: '/assets/wheels-up.png',
+    description: 'Aircraft loading planner',
+  },
+  {
+    title: 'Inventory Tracker',
+    image: '/assets/inventory-tracker.png',
+    description: 'Track and manage office supplies',
+  },
+  {
+    title: 'Budget Balanced',
+    image: '/assets/budget-balanced.png',
+    description: 'Personal budgeting app',
+  },
+  {
+    title: 'Marriage Managed',
+    image: '/assets/marriage-managed.png',
+    description: 'Wedding planning assistant',
+  },
+  {
+    title: 'US Business Directory',
+    image: '/assets/business-directory.png',
+    description: 'Private directory for sourcing',
+  },
+];
+
+export default function ProjectsCarousel() {
+  const [index, setIndex] = useState(0);
+
+  const prev = () => setIndex((index - 1 + projects.length) % projects.length);
+  const next = () => setIndex((index + 1) % projects.length);
+
+  return (
+    <div className="carousel">
+      <button className="carousel-button prev" aria-label="Previous project" onClick={prev}>
+        &#10094;
+      </button>
+      <div className="carousel-track-container">
+        <div
+          className="carousel-track"
+          style={{ transform: `translateX(-${index * 100}%)` }}
+        >
+          {projects.map((project) => (
+            <div className="carousel-slide" key={project.title}>
+              <img
+                src={project.image}
+                alt={`${project.title} screenshot`}
+                className="project-image"
+              />
+              <h3>{project.title}</h3>
+              <p>{project.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+      <button className="carousel-button next" aria-label="Next project" onClick={next}>
+        &#10095;
+      </button>
+    </div>
+  );
+}

--- a/style.css
+++ b/style.css
@@ -69,11 +69,14 @@ section h2 {
     margin: 0 auto;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 #projects .carousel-track-container {
     overflow: hidden;
     width: 100%;
+    max-width: 400px;
+    margin: 0 auto;
 }
 
 #projects .carousel-track {
@@ -96,13 +99,11 @@ section h2 {
 
 #projects .project-image {
     width: 100%;
-    height: 180px;
-    background: rgba(255, 255, 255, 0.1);
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    height: auto;
+    max-height: 250px;
+    object-fit: contain;
+    border-radius: 8px;
     margin-bottom: 10px;
-    color: #ddd;
 }
 
 #projects .carousel-button {


### PR DESCRIPTION
## Summary
- replace static project list with responsive carousel using project images and captions
- style carousel for centered layout and mobile-friendly images
- add React ProjectsCarousel component and App scaffold for future integration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aabb9020d88331bcf0605cd67f87e6