### PR TITLE
Add static background to subpages

### DIFF
--- a/budget-balanced.html
+++ b/budget-balanced.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="style.css" />
+  <title>Budget Balanced</title>
+</head>
+<body class="subpage-background">
+  <!-- Content coming soon -->
+</body>
+</html>

--- a/business-directory.html
+++ b/business-directory.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="style.css" />
+  <title>US Business Directory</title>
+</head>
+<body class="subpage-background">
+  <!-- Content coming soon -->
+</body>
+</html>

--- a/inventory-tracker.html
+++ b/inventory-tracker.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="style.css" />
+  <title>Inventory Tracker</title>
+</head>
+<body class="subpage-background">
+  <!-- Content coming soon -->
+</body>
+</html>

--- a/marriage-managed.html
+++ b/marriage-managed.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="style.css" />
+  <title>Marriage Managed</title>
+</head>
+<body class="subpage-background">
+  <!-- Content coming soon -->
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -134,3 +134,10 @@ section h2 {
     border-radius: 4px;
     font-weight: bold;
 }
+/* Full-screen static background for subpages */
+.subpage-background {
+    background: url('assets/subpage-background.png') no-repeat center center fixed;
+    background-size: cover;
+    min-height: 100vh;
+}
+

--- a/usbd.html
+++ b/usbd.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="style.css" />
+  <title>US Business Directory</title>
+</head>
+<body class="subpage-background">
+  <!-- Content coming soon -->
+</body>
+</html>

--- a/wheels-up.html
+++ b/wheels-up.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="style.css" />
+  <title>Wheels Up</title>
+</head>
+<body class="subpage-background">
+  <!-- Content coming soon -->
+</body>
+</html>


### PR DESCRIPTION
## Summary
- define `.subpage-background` class for a fixed, full-screen image
- add minimal HTML pages applying the background class for Wheels Up, Inventory Tracker, Budget Balanced, Marriage Managed, and US Business Directory

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bfe213448331992302e12f275ca2