### PR TITLE
Add Inventory Tracker page content

### DIFF
--- a/src/routes/inventory-tracker.svelte
+++ b/src/routes/inventory-tracker.svelte
@@ -1,0 +1,66 @@
+<script>
+  // No interactivity needed yet
+</script>
+
+<section class="inventory-tracker-page">
+  <div class="carousel">
+    <img src="/assets/inventory-tracker.png" alt="Inventory Tracker screenshot" />
+  </div>
+  <button class="cta-button">Use the App</button>
+  <div class="summary">
+    <p>The Inventory Tracker helps small businesses monitor stock levels and stay organized.</p>
+    <ul>
+      <li>Track inventory quantities across locations</li>
+      <li>Receive low-stock alerts</li>
+      <li>Import and export product lists</li>
+      <li>Generate easy-to-read reports</li>
+    </ul>
+  </div>
+</section>
+
+<style>
+  .inventory-tracker-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2rem 1rem;
+    text-align: center;
+  }
+
+  .carousel {
+    max-width: 600px;
+    width: 100%;
+  }
+
+  .carousel img {
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
+  }
+
+  .cta-button {
+    margin: 1.5rem auto;
+    padding: 0.75rem 1.5rem;
+    background-color: #fff;
+    color: #000;
+    border: none;
+    border-radius: 4px;
+    font-weight: bold;
+    cursor: pointer;
+  }
+
+  .summary {
+    max-width: 600px;
+  }
+
+  .summary ul {
+    text-align: left;
+    margin: 1rem 0 0;
+    padding-left: 1.25rem;
+  }
+
+  .summary li {
+    margin-bottom: 0.5rem;
+  }
+</style>
+


### PR DESCRIPTION
## Summary
- add Inventory Tracker subpage content with placeholder carousel image
- include non-functional "Use the App" button
- provide summary paragraph and bullet list of app features

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b11793a48c83318b8f8584f099d078