### PR TITLE
Add CMP consent banner and gated AdSense ads

### DIFF
--- a/budget-balanced.html
+++ b/budget-balanced.html
@@ -1,7 +1,33 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9205524998199511" crossorigin="anonymous"></script>
+  <!-- Google CMP -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9205524998199511?ers=1" nonce="cmp-nonce"></script>
+  <script>
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'width:0;height:0;border:0;display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied'
+    });
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="style.css" />

--- a/business-directory.html
+++ b/business-directory.html
@@ -1,7 +1,33 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9205524998199511" crossorigin="anonymous"></script>
+  <!-- Google CMP -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9205524998199511?ers=1" nonce="cmp-nonce"></script>
+  <script>
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'width:0;height:0;border:0;display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied'
+    });
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="style.css" />

--- a/index.html
+++ b/index.html
@@ -1,14 +1,37 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9205524998199511" crossorigin="anonymous"></script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XHKSDLZJ4J"></script>
+    <!-- Google CMP -->
+    <script async src="https://fundingchoicesmessages.google.com/i/pub-9205524998199511?ers=1" nonce="cmp-nonce"></script>
+    <script>
+      (function() {
+        function signalGooglefcPresent() {
+          if (!window.frames['googlefcPresent']) {
+            if (document.body) {
+              const iframe = document.createElement('iframe');
+              iframe.style.cssText = 'width:0;height:0;border:0;display:none';
+              iframe.name = 'googlefcPresent';
+              document.body.appendChild(iframe);
+            } else {
+              setTimeout(signalGooglefcPresent, 0);
+            }
+          }
+        }
+        signalGooglefcPresent();
+      })();
+    </script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
+      gtag('consent', 'default', {
+        'ad_storage': 'denied',
+        'analytics_storage': 'denied'
+      });
+    </script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XHKSDLZJ4J"></script>
+    <script>
       gtag('js', new Date());
-
       gtag('config', 'G-XHKSDLZJ4J');
     </script>
     <meta charset="UTF-8">

--- a/inventory-tracker.html
+++ b/inventory-tracker.html
@@ -1,11 +1,59 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9205524998199511" crossorigin="anonymous"></script>
+  <!-- Google CMP -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9205524998199511?ers=1" nonce="cmp-nonce"></script>
+  <script>
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'width:0;height:0;border:0;display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied'
+    });
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="style.css" />
   <title>Inventory Tracker</title>
+  <script>
+    function loadAds() {
+      const ads = document.createElement('script');
+      ads.src = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9205524998199511';
+      ads.async = true;
+      ads.crossOrigin = 'anonymous';
+      ads.onload = () => (adsbygoogle = window.adsbygoogle || []).push({});
+      document.head.appendChild(ads);
+    }
+
+    window.addEventListener('load', () => {
+      if (typeof window.__tcfapi === 'function') {
+        __tcfapi('addEventListener', 2, (tcData, success) => {
+          if (success && tcData.eventStatus === 'useractioncomplete') {
+            if (tcData.purpose.consents['1']) {
+              loadAds();
+            }
+          }
+        });
+      }
+    });
+  </script>
 </head>
 <body class="subpage-background">
   <div class="content-block">
@@ -22,6 +70,13 @@
     <p class="app-summary">
       Monitor and manage office supplies with real-time counts, low-stock alerts, and easy adjustments to keep inventory organized.
     </p>
-  </div>
+    <ins class="adsbygoogle"
+         style="display:block"
+         data-ad-client="ca-pub-9205524998199511"
+         data-ad-slot="1234567890"
+         data-ad-format="auto"
+         data-full-width-responsive="true"></ins>
+    <!-- Additional ad blocks can be added below -->
+    </div>
 </body>
 </html>

--- a/marriage-managed.html
+++ b/marriage-managed.html
@@ -1,7 +1,33 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9205524998199511" crossorigin="anonymous"></script>
+  <!-- Google CMP -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9205524998199511?ers=1" nonce="cmp-nonce"></script>
+  <script>
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'width:0;height:0;border:0;display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied'
+    });
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="style.css" />

--- a/usbd.html
+++ b/usbd.html
@@ -1,7 +1,33 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9205524998199511" crossorigin="anonymous"></script>
+  <!-- Google CMP -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9205524998199511?ers=1" nonce="cmp-nonce"></script>
+  <script>
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'width:0;height:0;border:0;display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied'
+    });
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="style.css" />

--- a/wheels-up.html
+++ b/wheels-up.html
@@ -1,7 +1,33 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9205524998199511" crossorigin="anonymous"></script>
+  <!-- Google CMP -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9205524998199511?ers=1" nonce="cmp-nonce"></script>
+  <script>
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'width:0;height:0;border:0;display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied'
+    });
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="style.css" />


### PR DESCRIPTION
## Summary
- integrate Google's CMP consent banner across all pages using Funding Choices script
- restrict AdSense loading to inventory-tracker page and initialize ads only after consent

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2077bff7c8331b99eb33513c1e9bb