### PR TITLE
feat: open inventory tracker in new tab

### DIFF
--- a/inventory-tracker.html
+++ b/inventory-tracker.html
@@ -66,7 +66,12 @@
         </div>
       </div>
     </div>
-    <button class="learn-more-button btn">Launch App</button>
+    <a
+      href="https://inventory.pistotestudio.com"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="learn-more-button btn"
+    >Launch App</a>
     <p class="app-summary">
       Monitor and manage office supplies with real-time counts, low-stock alerts, and easy adjustments to keep inventory organized.
     </p>


### PR DESCRIPTION
## Summary
- Link Inventory Tracker page's Launch App button to `https://inventory.pistotestudio.com`
- Open in new tab with `target="_blank"` and secure `rel` attributes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b34bfe7838833195d2c994838f64c9