### PR TITLE
feat: add adsense verification script

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
       gtag('js', new Date());
       gtag('config', 'G-XHKSDLZJ4J');
     </script>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9205524998199511" crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pistote Initiative Studio</title>


### PR DESCRIPTION
## Summary
- include Google AdSense verification script in main HTML head

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b37f413c608331a7379a47d1bd3bbe