### PR TITLE
Add Wheels Up app page with carousel and SEO summary

### DIFF
--- a/src/components/ProjectsCarousel.jsx
+++ b/src/components/ProjectsCarousel.jsx
@@ -6,7 +6,7 @@ const projects = [
     title: 'Wheels Up',
     image: '/assets/wheels-up.png',
     description: 'Aircraft loading planner',
-    path: '/wheels-up',
+    path: '/wheelsup',
   },
   {
     title: 'Inventory Tracker',

--- a/src/pages/WheelsUpPage.tsx
+++ b/src/pages/WheelsUpPage.tsx
@@ -1,9 +1,71 @@
+import { useState } from 'react';
 import SubpageLayout from '../components/SubpageLayout';
 
+const images = [
+  'https://via.placeholder.com/800x400?text=Wheels+Up+1',
+  'https://via.placeholder.com/800x400?text=Wheels+Up+2',
+  'https://via.placeholder.com/800x400?text=Wheels+Up+3',
+];
+
 export default function WheelsUpPage() {
+  const [index, setIndex] = useState(0);
+
+  const prev = () => setIndex((index - 1 + images.length) % images.length);
+  const next = () => setIndex((index + 1) % images.length);
+
   return (
     <SubpageLayout title="Wheels Up">
-      <p>Placeholder content for Wheels Up.</p>
+      <div className="carousel">
+        <button
+          className="carousel-button btn prev"
+          aria-label="Previous screenshot"
+          onClick={prev}
+        >
+          &#10094;
+        </button>
+        <div className="carousel-track-container">
+          <div
+            className="carousel-track"
+            style={{ transform: `translateX(-${index * 100}%)` }}
+          >
+            {images.map((src, i) => (
+              <div className="carousel-slide" key={src}>
+                <img src={src} alt={`Wheels Up screenshot ${i + 1}`} />
+              </div>
+            ))}
+          </div>
+        </div>
+        <button
+          className="carousel-button btn next"
+          aria-label="Next screenshot"
+          onClick={next}
+        >
+          &#10095;
+        </button>
+      </div>
+      <button type="button">Get App</button>
+      <section>
+        <h2>Ramp Loading Planner for Cargo &amp; ULD Management</h2>
+        <p>
+          <strong>Wheels Up</strong> is a ramp loading planner built for
+          <strong>ramp workers</strong>, <strong>cargo handlers</strong>, and
+          <strong>logistics teams</strong>. Streamline operations with an
+          intuitive interface dedicated to efficient <strong>ULD management</strong>
+          and cargo planning.
+        </p>
+        <ul>
+          <li>Drag-and-drop ULDs into aircraft positions</li>
+          <li>Persistent load plans that save automatically</li>
+          <li>Detailed plane view for accurate loading</li>
+          <li>Manage trains, tugs, and storage locations</li>
+          <li>Handle and flag Dangerous Goods for compliance</li>
+        </ul>
+        <p>
+          Perfect for teams who need reliable cargo coordination and fast ramp
+          turnaround.
+        </p>
+      </section>
     </SubpageLayout>
   );
 }
+

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -10,7 +10,7 @@ export default function AppRoutes() {
   return (
     <Routes>
       <Route path="/" element={<ProjectsCarousel />} />
-      <Route path="/wheels-up" element={<WheelsUpPage />} />
+      <Route path="/wheelsup" element={<WheelsUpPage />} />
       <Route path="/inventory-tracker" element={<InventoryTrackerPage />} />
       <Route path="/budget-balanced" element={<BudgetBalancedPage />} />
       <Route path="/marriage-managed" element={<MarriageManagedPage />} />


### PR DESCRIPTION
## Summary
- create Wheels Up page with image carousel, Get App button, and SEO-rich description
- add route and home carousel link for `/wheelsup`
- switch to remote placeholder screenshots and remove binary assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b60a0b18448331a80370b1681e0b9e