### PR TITLE
Link Wheels Up Learn More button to Wheels Up page

### DIFF
--- a/src/components/ProjectsCarousel.jsx
+++ b/src/components/ProjectsCarousel.jsx
@@ -51,7 +51,7 @@ export default function ProjectsCarousel() {
           style={{ transform: `translateX(-${index * 100}%)` }}
         >
           {projects.map((project) => (
-            <Link to={project.path} className="carousel-slide" key={project.title}>
+            <div className="carousel-slide" key={project.title}>
               <img
                 src={project.image}
                 alt={`${project.title} screenshot`}
@@ -59,7 +59,10 @@ export default function ProjectsCarousel() {
               />
               <h3>{project.title}</h3>
               <p>{project.description}</p>
-            </Link>
+              <Link to={project.path}>
+                <button type="button">Learn More</button>
+              </Link>
+            </div>
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add "Learn More" buttons to project carousel items
- Ensure Wheels Up button routes to `/wheelsup` subpage

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b60d72e1808331a4a66a4f2c07842a