### PR TITLE
Add site map page and footer link

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,9 @@
+import { Link } from 'react-router-dom';
+
+export default function Footer() {
+  return (
+    <footer style={{ marginTop: '2rem' }}>
+      <Link to="/sitemap">Site Map</Link>
+    </footer>
+  );
+}

--- a/src/components/ProjectsCarousel.jsx
+++ b/src/components/ProjectsCarousel.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import Footer from './Footer';
 
 const projects = [
   {
@@ -41,34 +42,37 @@ export default function ProjectsCarousel() {
   const next = () => setIndex((index + 1) % projects.length);
 
   return (
-    <div className="carousel">
-      <button className="carousel-button btn prev" aria-label="Previous project" onClick={prev}>
-        &#10094;
-      </button>
-      <div className="carousel-track-container">
-        <div
-          className="carousel-track"
-          style={{ transform: `translateX(-${index * 100}%)` }}
-        >
-          {projects.map((project) => (
-            <div className="carousel-slide" key={project.title}>
-              <img
-                src={project.image}
-                alt={`${project.title} screenshot`}
-                className="project-image"
-              />
-              <h3>{project.title}</h3>
-              <p>{project.description}</p>
-              <Link to={project.path}>
-                <button type="button">Learn More</button>
-              </Link>
-            </div>
-          ))}
+    <div>
+      <div className="carousel">
+        <button className="carousel-button btn prev" aria-label="Previous project" onClick={prev}>
+          &#10094;
+        </button>
+        <div className="carousel-track-container">
+          <div
+            className="carousel-track"
+            style={{ transform: `translateX(-${index * 100}%)` }}
+          >
+            {projects.map((project) => (
+              <div className="carousel-slide" key={project.title}>
+                <img
+                  src={project.image}
+                  alt={`${project.title} screenshot`}
+                  className="project-image"
+                />
+                <h3>{project.title}</h3>
+                <p>{project.description}</p>
+                <Link to={project.path}>
+                  <button type="button">Learn More</button>
+                </Link>
+              </div>
+            ))}
+          </div>
         </div>
+        <button className="carousel-button btn next" aria-label="Next project" onClick={next}>
+          &#10095;
+        </button>
       </div>
-      <button className="carousel-button btn next" aria-label="Next project" onClick={next}>
-        &#10095;
-      </button>
+      <Footer />
     </div>
   );
 }

--- a/src/components/SubpageLayout.tsx
+++ b/src/components/SubpageLayout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import background from '/assets/subpage-background.jpg';
+import Footer from './Footer';
 
 interface SubpageLayoutProps {
   title: string;
@@ -16,18 +17,28 @@ export default function SubpageLayout({ title, children }: SubpageLayoutProps) {
     minHeight: '100vh',
     display: 'flex',
     flexDirection: 'column',
-    justifyContent: 'center',
     alignItems: 'center',
     textAlign: 'center',
     color: '#fff',
     padding: '1rem',
   };
 
+  const contentStyle: React.CSSProperties = {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  };
+
   return (
     <div style={style}>
-      <h1>{title}</h1>
-      <div style={{ maxWidth: '600px' }}>{children}</div>
-      <Link to="/">Back to Home</Link>
+      <div style={contentStyle}>
+        <h1>{title}</h1>
+        <div style={{ maxWidth: '600px' }}>{children}</div>
+        <Link to="/">Back to Home</Link>
+      </div>
+      <Footer />
     </div>
   );
 }

--- a/src/pages/SiteMapPage.tsx
+++ b/src/pages/SiteMapPage.tsx
@@ -1,0 +1,19 @@
+import SubpageLayout from '../components/SubpageLayout';
+import { Link } from 'react-router-dom';
+
+export default function SiteMapPage() {
+  return (
+    <SubpageLayout title="Site Map">
+      <nav>
+        <ul>
+          <li><Link to="/">Home</Link></li>
+          <li><Link to="/inventory-tracker">Inventory Tracker</Link></li>
+          <li><Link to="/wheelsup">Wheels Up</Link></li>
+          <li><Link to="/budget-balanced">Budget Balanced</Link></li>
+          <li><Link to="/marriage-managed">Marriage Managed</Link></li>
+          <li><Link to="/business-directory">US Business Directory</Link></li>
+        </ul>
+      </nav>
+    </SubpageLayout>
+  );
+}

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -5,6 +5,7 @@ import InventoryTrackerPage from '../pages/InventoryTrackerPage';
 import BudgetBalancedPage from '../pages/BudgetBalancedPage';
 import MarriageManagedPage from '../pages/MarriageManagedPage';
 import BusinessDirectoryPage from '../pages/BusinessDirectoryPage';
+import SiteMapPage from '../pages/SiteMapPage';
 
 export default function AppRoutes() {
   return (
@@ -15,6 +16,7 @@ export default function AppRoutes() {
       <Route path="/budget-balanced" element={<BudgetBalancedPage />} />
       <Route path="/marriage-managed" element={<MarriageManagedPage />} />
       <Route path="/business-directory" element={<BusinessDirectoryPage />} />
+      <Route path="/sitemap" element={<SiteMapPage />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- add dedicated Site Map page listing key project links
- introduce reusable Footer with Site Map link
- register `/sitemap` route and render footer on all pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b61087e7188331ba18bb0757a40a39